### PR TITLE
Revert if a given `asset` was `not found` in the msg

### DIFF
--- a/contracts/SmartLoan.sol
+++ b/contracts/SmartLoan.sol
@@ -275,7 +275,10 @@ contract SmartLoan is OwnableUpgradeable, PriceAwareUpgradeable, ReentrancyGuard
 
 
   function getAssetPriceInAVAXWei(bytes32 _asset) internal view returns (uint256) {
-    uint normalizedPrice = (getPriceFromMsg(_asset) * 10 ** 18) / getPriceFromMsg(bytes32('AVAX'));
+    uint256 assetPrice = getPriceFromMsg(_asset);
+    uint256 avaxPrice = getPriceFromMsg(bytes32('AVAX'));
+    if (assetPrice == 0 || avaxPrice == 0) revert AssetPriceNotFoundInMsg();
+    uint normalizedPrice = (assetPrice * 10 ** 18) / (avaxPrice);
     return normalizedPrice;
   }
 
@@ -511,3 +514,6 @@ error InvestmentFailed();
 
 /// Redemption failed
 error RedemptionFailed();
+
+/// Price for a chosen asset not found
+error AssetPriceNotFoundInMsg();

--- a/test/integration/smart-loan.test.ts
+++ b/test/integration/smart-loan.test.ts
@@ -154,6 +154,19 @@ describe('Smart loan', () => {
       expect(await wrappedLoan.getLTV()).to.be.equal(0);
     });
 
+    it("should revert with AssetPriceNotFoundInMsg()", async () => {
+      let wrappedLoanWithoutPrices = WrapperBuilder
+          .mockLite(loan)
+          .using(
+              () => {
+                return {
+                  prices: [],
+                  timestamp: Date.now()
+                }
+              })
+      await expect(wrappedLoanWithoutPrices.getAssetValue(toBytes32("USD"))).to.be.revertedWith("AssetPriceNotFoundInMsg()");
+    });
+
     it("should provide assets balances and prices", async () => {
       const estimatedAVAXPriceFor1USDToken = await exchange.getEstimatedAVAXForERC20Token(toWei("1", usdTokenDecimalPlaces), usdTokenAddress);
       const usdTokenBalance = (await wrappedLoan.getAllAssetsBalances())[0];


### PR DESCRIPTION
* Revert if a given asset was not found in the msg

* ⚠️  Do not merge this PR prior to merging a corresponding PR in the redstone-adapter (https://github.com/redstone-finance/redstone-evm-connector/blob/4a0c91de5206176ed369c2b359bd07f734e7fe2c/contracts/message-based/PriceAwareUpgradeable.sol#L122-L135) 

---- update ----
Above PR has already been merged ✅ 