### PR TITLE
Make pangolin exchange upgradeable

### DIFF
--- a/contracts/PangolinExchange.sol
+++ b/contracts/PangolinExchange.sol
@@ -154,7 +154,7 @@ contract PangolinExchange is OwnableUpgradeable, IAssetsExchange, ReentrancyGuar
   /**
    * Returns the minimum AVAX amount that is required to buy _exactAmountOut of _token ERC20 token.
    **/
-  function getEstimatedAVAXForERC20Token(uint256 _exactAmountOut, address _token) public view virtual returns (uint256) {
+  function getEstimatedAVAXForERC20Token(uint256 _exactAmountOut, address _token) public view returns (uint256) {
     address[] memory path = getPathForAVAXtoToken(_token);
 
     return pangolinRouter.getAmountsIn(_exactAmountOut, path)[0];

--- a/contracts/PangolinExchange.sol
+++ b/contracts/PangolinExchange.sol
@@ -4,7 +4,7 @@ pragma solidity ^0.8.4;
 import "@pangolindex/exchange-contracts/contracts/pangolin-periphery/interfaces/IPangolinRouter.sol";
 import "@openzeppelin/contracts-upgradeable/security/ReentrancyGuardUpgradeable.sol";
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
-import "@openzeppelin/contracts/access/Ownable.sol";
+import "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
 import "@uniswap/lib/contracts/libraries/TransferHelper.sol";
 import "./interfaces/IAssetsExchange.sol";
 import "./lib/Bytes32EnumerableMap.sol";
@@ -14,7 +14,7 @@ import "./lib/Bytes32EnumerableMap.sol";
  * @dev Contract allows user to invest into an ERC20 token
  * This implementation uses the Pangolin DEX
  */
-contract PangolinExchange is Ownable, IAssetsExchange, ReentrancyGuardUpgradeable {
+contract PangolinExchange is OwnableUpgradeable, IAssetsExchange, ReentrancyGuardUpgradeable {
   using TransferHelper for address payable;
   using TransferHelper for address;
 
@@ -26,11 +26,11 @@ contract PangolinExchange is Ownable, IAssetsExchange, ReentrancyGuardUpgradeabl
 
   address private constant WAVAX_ADDRESS = 0xB31f66AA3C1e785363F0875A1B74E27b85FD66c7;
 
-  /* ========= CONSTRUCTOR ========= */
-
-  constructor(address _pangolinRouter, Asset[] memory supportedAssets) {
+  function initialize(address _pangolinRouter, Asset[] memory supportedAssets) external initializer {
     pangolinRouter = IPangolinRouter(_pangolinRouter);
     _updateAssets(supportedAssets);
+    __Ownable_init();
+    __ReentrancyGuard_init();
   }
 
   /**
@@ -154,7 +154,7 @@ contract PangolinExchange is Ownable, IAssetsExchange, ReentrancyGuardUpgradeabl
   /**
    * Returns the minimum AVAX amount that is required to buy _exactAmountOut of _token ERC20 token.
    **/
-  function getEstimatedAVAXForERC20Token(uint256 _exactAmountOut, address _token) public view returns (uint256) {
+  function getEstimatedAVAXForERC20Token(uint256 _exactAmountOut, address _token) public view virtual returns (uint256) {
     address[] memory path = getPathForAVAXtoToken(_token);
 
     return pangolinRouter.getAmountsIn(_exactAmountOut, path)[0];

--- a/contracts/PangolinExchange.sol
+++ b/contracts/PangolinExchange.sol
@@ -22,7 +22,7 @@ contract PangolinExchange is OwnableUpgradeable, IAssetsExchange, ReentrancyGuar
   IPangolinRouter pangolinRouter;
 
   using EnumerableMap for EnumerableMap.Bytes32ToAddressMap;
-  EnumerableMap.Bytes32ToAddressMap private map;
+  EnumerableMap.Bytes32ToAddressMap private supportedAssetsMap;
 
   address private constant WAVAX_ADDRESS = 0xB31f66AA3C1e785363F0875A1B74E27b85FD66c7;
 
@@ -90,7 +90,7 @@ contract PangolinExchange is OwnableUpgradeable, IAssetsExchange, ReentrancyGuar
       require(_assets[i].asset != "", "Cannot set an empty string asset.");
       require(_assets[i].assetAddress != address(0), "Cannot set an empty address.");
 
-      EnumerableMap.set(map, _assets[i].asset, _assets[i].assetAddress);
+      EnumerableMap.set(supportedAssetsMap, _assets[i].asset, _assets[i].assetAddress);
     }
 
     emit AssetsAdded(_assets);
@@ -110,7 +110,7 @@ contract PangolinExchange is OwnableUpgradeable, IAssetsExchange, ReentrancyGuar
    **/
   function removeAssets(bytes32[] calldata _assets) external override onlyOwner {
     for (uint256 i = 0; i < _assets.length; i++) {
-      EnumerableMap.remove(map, _assets[i]);
+      EnumerableMap.remove(supportedAssetsMap, _assets[i]);
     }
 
     emit AssetsRemoved(_assets);
@@ -120,14 +120,14 @@ contract PangolinExchange is OwnableUpgradeable, IAssetsExchange, ReentrancyGuar
    * Returns all the supported assets keys
    **/
   function getAllAssets() external view override returns (bytes32[] memory result) {
-    return map._inner._keys._inner._values;
+    return supportedAssetsMap._inner._keys._inner._values;
   }
 
   /**
    * Returns address of an asset
    **/
   function getAssetAddress(bytes32 _asset) public view override returns (address) {
-    (, address assetAddress) = EnumerableMap.tryGet(map, _asset);
+    (, address assetAddress) = EnumerableMap.tryGet(supportedAssetsMap, _asset);
     require(assetAddress != address(0), "Asset not supported.");
 
     return assetAddress;

--- a/contracts/Pool.sol
+++ b/contracts/Pool.sol
@@ -43,6 +43,7 @@ contract Pool is OwnableUpgradeable, ReentrancyGuardUpgradeable, IERC20 {
     borrowIndex = address(borrowIndex_) == address(0) ? new CompoundingIndex() : borrowIndex_;
 
     __Ownable_init();
+    __ReentrancyGuard_init();
     _updateRates();
   }
 

--- a/contracts/SmartLoan.sol
+++ b/contracts/SmartLoan.sol
@@ -67,6 +67,9 @@ contract SmartLoan is OwnableUpgradeable, PriceAwareUpgradeable, ReentrancyGuard
     exchange.sellAsset(asset, _amount, _minAvaxOut);
   }
 
+  /**
+   * @dev This function uses the redstone-evm-connector
+  **/
   function withdrawAsset(bytes32 asset, uint256 amount) external onlyOwner nonReentrant remainsSolvent {
     IERC20Metadata token = getERC20TokenInstance(asset);
     address(token).safeTransfer(msg.sender, amount);
@@ -94,6 +97,7 @@ contract SmartLoan is OwnableUpgradeable, PriceAwareUpgradeable, ReentrancyGuard
   /**
    * This function attempts to repay the _repayAmount back to the pool.
    * If there is not enough AVAX balance to repay the _repayAmount then the available AVAX balance will be repaid.
+   * @dev This function uses the redstone-evm-connector
    **/
   function attemptRepay(uint256 _repayAmount) internal {
     repay(Math.min(address(this).balance, _repayAmount));
@@ -105,6 +109,7 @@ contract SmartLoan is OwnableUpgradeable, PriceAwareUpgradeable, ReentrancyGuard
 
   /**
    * This function can only be accessed by the owner and allows selling all of the assets.
+   * @dev This function uses the redstone-evm-connector
    **/
   function closeLoan() external payable onlyOwner nonReentrant remainsSolvent {
     bytes32[] memory assets = exchange.getAllAssets();
@@ -127,6 +132,9 @@ contract SmartLoan is OwnableUpgradeable, PriceAwareUpgradeable, ReentrancyGuard
     }
   }
 
+  /**
+  * @dev This function uses the redstone-evm-connector
+  **/
   function liquidateLoan(uint256 repayAmount) external payable nonReentrant successfulLiquidation {
     if (isSolvent()) revert LoanSolvent();
 
@@ -160,6 +168,7 @@ contract SmartLoan is OwnableUpgradeable, PriceAwareUpgradeable, ReentrancyGuard
    * This method could be used to cash out profits from investments
    * The loan needs to remain solvent after the withdrawal
    * @param _amount to be withdrawn
+   * @dev This function uses the redstone-evm-connector
    **/
   function withdraw(uint256 _amount) public onlyOwner nonReentrant remainsSolvent {
     if (address(this).balance < _amount) revert InsufficientFundsForWithdrawal();
@@ -174,6 +183,7 @@ contract SmartLoan is OwnableUpgradeable, PriceAwareUpgradeable, ReentrancyGuard
    * @param _asset code of the asset
    * @param _exactERC20AmountOut exact amount of asset to buy
    * @param _maxAvaxAmountIn maximum amount of AVAX to sell
+   * @dev This function uses the redstone-evm-connector
    **/
   function invest(bytes32 _asset, uint256 _exactERC20AmountOut, uint256 _maxAvaxAmountIn) external onlyOwner nonReentrant remainsSolvent {
     if (address(this).balance < _maxAvaxAmountIn) revert InsufficientFundsForInvestment();
@@ -189,6 +199,7 @@ contract SmartLoan is OwnableUpgradeable, PriceAwareUpgradeable, ReentrancyGuard
    * @param _asset code of the asset
    * @param _exactERC20AmountIn exact amount of token to sell
    * @param _minAvaxAmountOut minimum amount of the AVAX token to buy
+   * @dev This function uses the redstone-evm-connector
    **/
   function redeem(bytes32 _asset, uint256 _exactERC20AmountIn, uint256 _minAvaxAmountOut) external nonReentrant onlyOwner remainsSolvent {
     IERC20Metadata token = getERC20TokenInstance(_asset);
@@ -202,6 +213,7 @@ contract SmartLoan is OwnableUpgradeable, PriceAwareUpgradeable, ReentrancyGuard
   /**
    * Borrows funds from the pool
    * @param _amount of funds to borrow
+   * @dev This function uses the redstone-evm-connector
    **/
   function borrow(uint256 _amount) external onlyOwner remainsSolvent {
     pool.borrow(_amount);
@@ -212,6 +224,7 @@ contract SmartLoan is OwnableUpgradeable, PriceAwareUpgradeable, ReentrancyGuard
   /**
    * Repays funds to the pool
    * @param _amount of funds to repay
+   * @dev This function uses the redstone-evm-connector
    **/
   function repay(uint256 _amount) public payable {
     if (isSolvent()) {
@@ -232,6 +245,7 @@ contract SmartLoan is OwnableUpgradeable, PriceAwareUpgradeable, ReentrancyGuard
 
   /**
    * Returns the current value of a loan including cash and investments
+   * @dev This function uses the redstone-evm-connector
    **/
   function getTotalValue() public view virtual returns (uint256) {
     uint256 total = address(this).balance;
@@ -259,6 +273,9 @@ contract SmartLoan is OwnableUpgradeable, PriceAwareUpgradeable, ReentrancyGuard
     return token;
   }
 
+  /**
+  * @dev This function uses the redstone-evm-connector
+  **/
   function getAssetPriceInAVAXWei(bytes32 _asset) internal view returns (uint256) {
     uint256 assetPrice = getPriceFromMsg(_asset);
     uint256 avaxPrice = getPriceFromMsg(bytes32("AVAX"));
@@ -277,6 +294,7 @@ contract SmartLoan is OwnableUpgradeable, PriceAwareUpgradeable, ReentrancyGuard
   /**
    * LoanToValue ratio is calculated as the ratio between debt and collateral.
    * The collateral is equal to total loan value takeaway debt.
+   * @dev This function uses the redstone-evm-connector
    **/
   function getLTV() public view returns (uint256) {
     uint256 debt = getDebt();
@@ -298,6 +316,7 @@ contract SmartLoan is OwnableUpgradeable, PriceAwareUpgradeable, ReentrancyGuard
    * Checks if the loan is solvent.
    * It means that the ratio between debt and collateral is below safe level,
    * which is parametrized by the MAX_LTV
+   * @dev This function uses the redstone-evm-connector
    **/
   function isSolvent() public view returns (bool) {
     return getLTV() < MAX_LTV;
@@ -306,6 +325,7 @@ contract SmartLoan is OwnableUpgradeable, PriceAwareUpgradeable, ReentrancyGuard
   /**
    * Returns the value held on the loan contract in a given asset
    * @param _asset the code of the given asset
+   * @dev This function uses the redstone-evm-connector
    **/
   function getAssetValue(bytes32 _asset) public view returns (uint256) {
     IERC20Metadata token = getERC20TokenInstance(_asset);
@@ -335,6 +355,7 @@ contract SmartLoan is OwnableUpgradeable, PriceAwareUpgradeable, ReentrancyGuard
   /**
    * Returns the prices of all assets served by the price provider
    * It could be used as a helper method for UI
+   * @dev This function uses the redstone-evm-connector
    **/
   function getAllAssetsPrices() public view returns (uint256[] memory) {
     bytes32[] memory assets = exchange.getAllAssets();
@@ -349,6 +370,9 @@ contract SmartLoan is OwnableUpgradeable, PriceAwareUpgradeable, ReentrancyGuard
 
   /* ========== MODIFIERS ========== */
 
+  /**
+  * @dev This modifier uses the redstone-evm-connector
+  **/
   modifier remainsSolvent() {
     _;
     if (!isSolvent()) revert LoanInsolvent();
@@ -359,6 +383,7 @@ contract SmartLoan is OwnableUpgradeable, PriceAwareUpgradeable, ReentrancyGuard
    * If the liquidateLoan() was not called by the owner then an additional check of making sure that LTV > MIN_SELLOUT_LTV is applied.
    * It protects the user from an unnecessarily costly liquidation.
    * The loan must be solvent after the liquidateLoan() operation.
+   * @dev This modifier uses the redstone-evm-connector
    **/
   modifier successfulLiquidation() {
     _;

--- a/contracts/SmartLoan.sol
+++ b/contracts/SmartLoan.sol
@@ -39,6 +39,7 @@ contract SmartLoan is OwnableUpgradeable, PriceAwareUpgradeable, ReentrancyGuard
     pool = pool_;
     __Ownable_init();
     __PriceAware_init();
+    __ReentrancyGuard_init();
   }
 
   /**

--- a/contracts/SmartLoansFactory.sol
+++ b/contracts/SmartLoansFactory.sol
@@ -5,6 +5,7 @@ import "./SmartLoan.sol";
 import "./Pool.sol";
 import "./interfaces/IAssetsExchange.sol";
 import "@openzeppelin/contracts/proxy/beacon/UpgradeableBeacon.sol";
+import "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
 import "@openzeppelin/contracts/proxy/beacon/BeaconProxy.sol";
 
 /**
@@ -14,7 +15,7 @@ import "@openzeppelin/contracts/proxy/beacon/BeaconProxy.sol";
  * and could be authorised to access the lending pool.
  *
  */
-contract SmartLoansFactory is IBorrowersRegistry {
+contract SmartLoansFactory is OwnableUpgradeable, IBorrowersRegistry {
   modifier oneLoanPerOwner() {
     if (ownersToLoans[msg.sender] != address(0)) revert TooManyLoans();
     _;
@@ -31,7 +32,7 @@ contract SmartLoansFactory is IBorrowersRegistry {
 
   SmartLoan[] loans;
 
-  constructor(Pool _pool, IAssetsExchange _assetsExchange) {
+  function initialize(Pool _pool, IAssetsExchange _assetsExchange) external initializer {
     pool = _pool;
     assetsExchange = _assetsExchange;
     SmartLoan smartLoanImplementation = new SmartLoan();

--- a/contracts/mock/MockUpgradedPangolinExchange.sol
+++ b/contracts/mock/MockUpgradedPangolinExchange.sol
@@ -1,0 +1,13 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.4;
+
+import "../PangolinExchange.sol";
+
+contract MockUpgradedPangolinExchange is PangolinExchange{
+    /**
+   * Returns a mocked 1337 value;
+   **/
+    function getEstimatedAVAXForERC20Token(uint256 _exactAmountOut, address _token) override public view returns (uint256) {
+        return 1337;
+    }
+}

--- a/contracts/mock/MockUpgradedPangolinExchange.sol
+++ b/contracts/mock/MockUpgradedPangolinExchange.sol
@@ -7,7 +7,7 @@ contract MockUpgradedPangolinExchange is PangolinExchange{
     /**
    * Returns a mocked 1337 value;
    **/
-    function getEstimatedAVAXForERC20Token(uint256 _exactAmountOut, address _token) override public view returns (uint256) {
+    function newMockedFunction(uint256 _exactAmountOut, address _token) public view returns (uint256) {
         return 1337;
     }
 }

--- a/contracts/mock/MockUpgradedSmartLoan.sol
+++ b/contracts/mock/MockUpgradedSmartLoan.sol
@@ -35,6 +35,7 @@ contract MockUpgradedSmartLoan is OwnableUpgradeable, PriceAwareUpgradeable, Ree
     pool = pool_;
     __Ownable_init();
     __PriceAware_init();
+    __ReentrancyGuard_init();
   }
 
   /**

--- a/contracts/mock/MockUpgradedSmartLoansFactory.sol
+++ b/contracts/mock/MockUpgradedSmartLoansFactory.sol
@@ -1,9 +1,9 @@
 // SPDX-License-Identifier: UNLICENSED
 pragma solidity ^0.8.4;
 
-import "../PangolinExchange.sol";
+import "../SmartLoansFactory.sol";
 
-contract MockUpgradedPangolinExchange is PangolinExchange{
+contract MockUpgradedSmartLoansFactory is SmartLoansFactory{
     /**
    * Returns a mocked 1337 value;
    **/

--- a/test/_helpers.ts
+++ b/test/_helpers.ts
@@ -68,8 +68,8 @@ export const deployAndInitPangolinExchangeContract = async function (
     pangolinRouterAddress: string,
     supportedAssets: Asset[]
   ) {
-  const exchange = await deployContract(owner, PangolinExchangeArtifact, [pangolinRouterAddress, supportedAssets]) as PangolinExchange;
-
+  const exchange = await deployContract(owner, PangolinExchangeArtifact) as PangolinExchange;
+  exchange.initialize(pangolinRouterAddress, supportedAssets);
   return exchange
 };
 

--- a/test/integration/pangolin-exchange.test.ts
+++ b/test/integration/pangolin-exchange.test.ts
@@ -44,7 +44,8 @@ describe('PangolinExchange', () => {
     before('Deploy the PangolinExchange contract', async () => {
       [,owner] = await getFixedGasSigners(10000000);
 
-      sut = await deployContract(owner, PangolinExchangeArtifact, [pangolinRouterAddress, [{ asset: toBytes32('DAI'), assetAddress: daiTokenAddress}]]) as PangolinExchange;
+      sut = await deployContract(owner, PangolinExchangeArtifact) as PangolinExchange;
+      await sut.initialize(pangolinRouterAddress, [{ asset: toBytes32('DAI'), assetAddress: daiTokenAddress}]);
 
       daiToken = await new ethers.Contract(daiTokenAddress, ERC20Abi);
       pangolinRouter = await new ethers.Contract(pangolinRouterAddress, pangolinRouterAbi);
@@ -133,8 +134,8 @@ describe('PangolinExchange', () => {
 
       [owner] = await getFixedGasSigners(10000000);
       let token1 = "TOKEN_1";
-      contract = await deployContract(owner, PangolinExchangeArtifact, [pangolinRouterAddress, [new Asset(toBytes32(token1), token1Address)]]) as PangolinExchange;
-      sut = contract;
+      sut = await deployContract(owner, PangolinExchangeArtifact) as PangolinExchange;
+      await sut.initialize(pangolinRouterAddress, [new Asset(toBytes32(token1), token1Address)]);
     });
 
     it("should add asset at a contract deploy", async () => {
@@ -306,7 +307,8 @@ describe('PangolinExchange', () => {
 
       [,owner2] = await getFixedGasSigners(10000000);
 
-      sut2 = await deployContract(owner2, PangolinExchangeArtifact, [pangolinRouterAddress, []]) as PangolinExchange;
+      sut2 = await deployContract(owner2, PangolinExchangeArtifact) as PangolinExchange;
+      await sut2.initialize(pangolinRouterAddress, []);
       expect(await sut2.getAllAssets()).to.be.empty;
     });
   });

--- a/test/integration/smart-loan.test.ts
+++ b/test/integration/smart-loan.test.ts
@@ -396,7 +396,8 @@ describe('Smart loan',  () => {
     });
 
     it("should deploy a smart loan behind a proxy", async () => {
-      smartLoansFactory = await deployContract(owner, SmartLoansFactoryArtifact, [pool.address, exchange.address]) as SmartLoansFactory;
+      smartLoansFactory = await deployContract(owner, SmartLoansFactoryArtifact) as SmartLoansFactory;
+      await smartLoansFactory.initialize(pool.address, exchange.address);
 
       const beaconAddress = await smartLoansFactory.upgradeableBeacon.call(0);
       beacon = (await new ethers.Contract(beaconAddress, UpgradeableBeaconArtifact.abi) as UpgradeableBeacon).connect(owner);
@@ -778,7 +779,7 @@ describe('Smart loan',  () => {
       expect(await wrappedLoan.getLTV()).to.be.equal(3000);
 
       const slippageTolerance = 0.03;
-      let investedAmount = 20000;
+      let investedAmount = 15000;
       let requiredAvaxAmount = USD_PRICE * investedAmount * (1 + slippageTolerance) / AVAX_PRICE;
 
       await wrappedLoan.invest(
@@ -843,7 +844,7 @@ describe('Smart loan',  () => {
 
       // Make sure that the loan returned all of the remaining AVAX after repaying the whole debt
       expect(await provider.getBalance(loan.address)).to.be.equal(0);
-      expect(fromWei(await provider.getBalance(owner.address))).to.be.closeTo(fromWei(expectedOwnerAvaxBalance), 2);
+      expect(fromWei(await provider.getBalance(owner.address))).to.be.closeTo(fromWei(expectedOwnerAvaxBalance), 1);
     });
   });
 
@@ -931,7 +932,7 @@ describe('Smart loan',  () => {
       expect(await wrappedLoan.getLTV()).to.be.equal(3000);
 
       const slippageTolerance = 0.03;
-      let investedAmount = 20000;
+      let investedAmount = 15000;
       let requiredAvaxAmount = USD_PRICE * investedAmount * (1 + slippageTolerance) / AVAX_PRICE;
 
       await wrappedLoan.invest(
@@ -1083,7 +1084,7 @@ describe('Smart loan',  () => {
       expect(await wrappedLoan.getLTV()).to.be.equal(3000);
 
       const slippageTolerance = 0.03;
-      let investedAmount = 20000;
+      let investedAmount = 15000;
       let requiredAvaxAmount = USD_PRICE * investedAmount * (1 + slippageTolerance) / AVAX_PRICE;
 
       await wrappedLoan.invest(
@@ -1102,7 +1103,7 @@ describe('Smart loan',  () => {
     });
 
     it('should revert on a withdrawal resulting in an insolvent loan', async () => {
-      await expect(wrappedLoan.withdrawAsset(toBytes32("USD"), parseUnits("20000", usdTokenDecimalPlaces))).to.be.revertedWith("LoanInsolvent()");
+      await expect(wrappedLoan.withdrawAsset(toBytes32("USD"), parseUnits("15000", usdTokenDecimalPlaces))).to.be.revertedWith("LoanInsolvent()");
     });
 
     it('should withdraw', async () => {
@@ -1196,7 +1197,7 @@ describe('Smart loan',  () => {
             expect(await wrappedLoan.getLTV()).to.be.equal(3000);
 
             const slippageTolerance = 0.03;
-            let investedAmount = 20000;
+            let investedAmount = 15000;
             let requiredAvaxAmount = USD_PRICE * investedAmount * (1 + slippageTolerance) / AVAX_PRICE;
 
             await wrappedLoan.invest(

--- a/test/integration/smart-loan.test.ts
+++ b/test/integration/smart-loan.test.ts
@@ -843,7 +843,7 @@ describe('Smart loan',  () => {
 
       // Make sure that the loan returned all of the remaining AVAX after repaying the whole debt
       expect(await provider.getBalance(loan.address)).to.be.equal(0);
-      expect(fromWei(await provider.getBalance(owner.address))).to.be.closeTo(fromWei(expectedOwnerAvaxBalance), 1);
+      expect(fromWei(await provider.getBalance(owner.address))).to.be.closeTo(fromWei(expectedOwnerAvaxBalance), 2);
     });
   });
 

--- a/test/integration/upgrade-pangolin-exchange.test.ts
+++ b/test/integration/upgrade-pangolin-exchange.test.ts
@@ -1,0 +1,58 @@
+import {Asset, deployAndInitPangolinExchangeContract, syncTime, toBytes32} from "../_helpers";
+import {
+    MockUpgradedPangolinExchange__factory,
+    PangolinExchange, PangolinExchange__factory, Pool__factory, TransparentUpgradeableProxy,
+    TransparentUpgradeableProxy__factory,
+    UpgradeableBeacon
+} from "../../typechain";
+import {SignerWithAddress} from "@nomiclabs/hardhat-ethers/signers";
+import chai, {expect} from "chai";
+import {solidity} from "ethereum-waffle";
+import {ethers, waffle} from "hardhat";
+import {getFixedGasSigners} from "../_helpers";
+
+chai.use(solidity);
+
+const {deployContract, provider} = waffle;
+
+const ZERO = ethers.constants.AddressZero;
+const pangolinRouterAddress = '0xE54Ca86531e17Ef3616d22Ca28b0D458b6C89106';
+const usdTokenAddress = '0xc7198437980c041c805a1edcba50c1ce5db95118';
+
+describe('Smart loan - upgrading',  () => {
+    before("Synchronize blockchain time", async () => {
+        await syncTime();
+    });
+
+    describe('Check basic logic before and after upgrade', () => {
+        let exchange: PangolinExchange,
+            owner: SignerWithAddress,
+            admin: SignerWithAddress,
+            proxy: TransparentUpgradeableProxy;
+        before("should deploy provider, exchange, loansFactory and pool", async () => {
+            [, owner, admin] = await getFixedGasSigners(10000000);
+            exchange = await deployAndInitPangolinExchangeContract(owner, pangolinRouterAddress, [new Asset(toBytes32('USD'), usdTokenAddress)]);
+
+            proxy = await (new TransparentUpgradeableProxy__factory(owner).deploy(exchange.address, admin.address, []));
+            exchange = await (new PangolinExchange__factory(owner).attach(proxy.address));
+
+            await exchange.connect(owner).initialize(pangolinRouterAddress, [new Asset(toBytes32('USD'), usdTokenAddress)]);
+        });
+
+        it("should not allow to upgrade from non-owner", async () => {
+            const exchangeV2 = await (new MockUpgradedPangolinExchange__factory(owner).deploy());
+            await expect(proxy.connect(owner).upgradeTo(exchangeV2.address))
+                .to.be.revertedWith("Transaction reverted: function selector was not recognized and there's no fallback function");
+        });
+
+
+        it("should upgrade", async () => {
+            const exchangeV2 = await (new MockUpgradedPangolinExchange__factory(owner).deploy());
+
+            await proxy.connect(admin).upgradeTo(exchangeV2.address);
+
+            //The mock exchange has a hardcoded return value of 1337
+            expect(await exchange.connect(owner).getEstimatedAVAXForERC20Token(0, ZERO)).to.be.equal(1337);
+        });
+    });
+});

--- a/test/integration/upgrade-pangolin-exchange.test.ts
+++ b/test/integration/upgrade-pangolin-exchange.test.ts
@@ -1,10 +1,11 @@
 import {Asset, deployAndInitPangolinExchangeContract, syncTime, toBytes32} from "../_helpers";
 import {
+    MockUpgradedPangolinExchange,
     MockUpgradedPangolinExchange__factory,
-    PangolinExchange, PangolinExchange__factory, Pool__factory, TransparentUpgradeableProxy,
+    PangolinExchange, PangolinExchange__factory, TransparentUpgradeableProxy,
     TransparentUpgradeableProxy__factory,
-    UpgradeableBeacon
 } from "../../typechain";
+import MockPangolinExchangeArtifact from '../../artifacts/contracts/mock/MockUpgradedPangolinExchange.sol/MockUpgradedPangolinExchange.json';
 import {SignerWithAddress} from "@nomiclabs/hardhat-ethers/signers";
 import chai, {expect} from "chai";
 import {solidity} from "ethereum-waffle";
@@ -12,8 +13,6 @@ import {ethers, waffle} from "hardhat";
 import {getFixedGasSigners} from "../_helpers";
 
 chai.use(solidity);
-
-const {deployContract, provider} = waffle;
 
 const ZERO = ethers.constants.AddressZero;
 const pangolinRouterAddress = '0xE54Ca86531e17Ef3616d22Ca28b0D458b6C89106';
@@ -51,8 +50,10 @@ describe('Smart loan - upgrading',  () => {
 
             await proxy.connect(admin).upgradeTo(exchangeV2.address);
 
+            let exchangeUpgraded = (await new ethers.Contract(exchange.address, MockPangolinExchangeArtifact.abi)) as MockUpgradedPangolinExchange;
+
             //The mock exchange has a hardcoded return value of 1337
-            expect(await exchange.connect(owner).getEstimatedAVAXForERC20Token(0, ZERO)).to.be.equal(1337);
+            expect(await exchangeUpgraded.connect(owner).newMockedFunction(0, ZERO)).to.be.equal(1337);
         });
     });
 });

--- a/test/integration/upgrade-pangolin-exchange.test.ts
+++ b/test/integration/upgrade-pangolin-exchange.test.ts
@@ -9,16 +9,15 @@ import MockPangolinExchangeArtifact from '../../artifacts/contracts/mock/MockUpg
 import {SignerWithAddress} from "@nomiclabs/hardhat-ethers/signers";
 import chai, {expect} from "chai";
 import {solidity} from "ethereum-waffle";
-import {ethers, waffle} from "hardhat";
+import {ethers} from "hardhat";
 import {getFixedGasSigners} from "../_helpers";
 
 chai.use(solidity);
 
-const ZERO = ethers.constants.AddressZero;
 const pangolinRouterAddress = '0xE54Ca86531e17Ef3616d22Ca28b0D458b6C89106';
 const usdTokenAddress = '0xc7198437980c041c805a1edcba50c1ce5db95118';
 
-describe('Smart loan - upgrading',  () => {
+describe('Pangolin Exchange - upgrading',  () => {
     before("Synchronize blockchain time", async () => {
         await syncTime();
     });
@@ -53,7 +52,7 @@ describe('Smart loan - upgrading',  () => {
             let exchangeUpgraded = (await new ethers.Contract(exchange.address, MockPangolinExchangeArtifact.abi)) as MockUpgradedPangolinExchange;
 
             //The mock exchange has a hardcoded return value of 1337
-            expect(await exchangeUpgraded.connect(owner).newMockedFunction(0, ZERO)).to.be.equal(1337);
+            expect(await exchangeUpgraded.connect(owner).newMockedFunction()).to.be.equal(1337);
         });
     });
 });

--- a/test/integration/upgrade-smart-loan.test.ts
+++ b/test/integration/upgrade-smart-loan.test.ts
@@ -79,7 +79,8 @@ describe('Smart loan - upgrading',  () => {
       usdTokenContract = new ethers.Contract(usdTokenAddress, erc20ABI, provider);
       exchange = await deployAndInitPangolinExchangeContract(owner, pangolinRouterAddress, [new Asset(toBytes32('USD'), usdTokenAddress)]);
 
-      smartLoansFactory = await deployContract(owner, SmartLoansFactoryArtifact, [pool.address, exchange.address]) as SmartLoansFactory;
+      smartLoansFactory = await deployContract(owner, SmartLoansFactoryArtifact) as SmartLoansFactory;
+      smartLoansFactory.initialize(pool.address, exchange.address);
 
       const borrowersRegistry = await (new OpenBorrowersRegistry__factory(owner).deploy());
       const beaconAddress = await smartLoansFactory.upgradeableBeacon.call(0);

--- a/test/integration/upgrade-smart-loans-factory.test.ts
+++ b/test/integration/upgrade-smart-loans-factory.test.ts
@@ -50,7 +50,7 @@ describe('Smart loans factory - upgrading',  () => {
             ownerLoanAddress = await smartLoansFactory.getLoanForOwner(owner.address);
         });
 
-        it("should not allow to upgrade from non-owner", async () => {
+        it("should not allow to upgrade from non-admin", async () => {
             const smartLoansFactoryV2 = await (new MockUpgradedSmartLoansFactory__factory(owner).deploy());
             await expect(proxy.connect(owner).upgradeTo(smartLoansFactoryV2.address))
                 .to.be.revertedWith("Transaction reverted: function selector was not recognized and there's no fallback function");

--- a/test/integration/upgrade-smart-loans-factory.test.ts
+++ b/test/integration/upgrade-smart-loans-factory.test.ts
@@ -1,0 +1,73 @@
+import {Asset, deployAndInitPangolinExchangeContract, syncTime, toBytes32} from "../_helpers";
+import {
+    MockUpgradedSmartLoansFactory,
+    MockUpgradedSmartLoansFactory__factory,
+    PangolinExchange,
+    Pool,
+    SmartLoansFactory,
+    SmartLoansFactory__factory,
+    TransparentUpgradeableProxy,
+    TransparentUpgradeableProxy__factory,
+} from "../../typechain";
+import MockSmartLoansFactoryArtifact from '../../artifacts/contracts/mock/MockUpgradedSmartLoansFactory.sol/MockUpgradedSmartLoansFactory.json';
+import {SignerWithAddress} from "@nomiclabs/hardhat-ethers/signers";
+import PoolArtifact from '../../artifacts/contracts/Pool.sol/Pool.json';
+import chai, {expect} from "chai";
+import {deployContract, solidity} from "ethereum-waffle";
+import {ethers} from "hardhat";
+import {getFixedGasSigners} from "../_helpers";
+
+chai.use(solidity);
+
+const pangolinRouterAddress = '0xE54Ca86531e17Ef3616d22Ca28b0D458b6C89106';
+const usdTokenAddress = '0xc7198437980c041c805a1edcba50c1ce5db95118';
+
+describe('Smart loans factory - upgrading',  () => {
+    before("Synchronize blockchain time", async () => {
+        await syncTime();
+    });
+
+    describe('Check basic logic before and after upgrade', () => {
+        let smartLoansFactory: SmartLoansFactory,
+            pool: Pool,
+            exchange: PangolinExchange,
+            owner: SignerWithAddress,
+            admin: SignerWithAddress,
+            proxy: TransparentUpgradeableProxy,
+            ownerLoanAddress: any;
+        before("should deploy provider, exchange, loansFactory and pool", async () => {
+            [, owner, admin] = await getFixedGasSigners(10000000);
+            pool = (await deployContract(owner, PoolArtifact)) as Pool;
+            exchange = await deployAndInitPangolinExchangeContract(owner, pangolinRouterAddress, [new Asset(toBytes32('USD'), usdTokenAddress)]);
+            smartLoansFactory = await (new SmartLoansFactory__factory(owner).deploy());
+
+            proxy = await (new TransparentUpgradeableProxy__factory(owner).deploy(smartLoansFactory.address, admin.address, []));
+            smartLoansFactory = await (new SmartLoansFactory__factory(owner).attach(proxy.address));
+
+            await smartLoansFactory.connect(owner).initialize(pool.address, exchange.address);
+
+            await smartLoansFactory.createLoan();
+            ownerLoanAddress = await smartLoansFactory.getLoanForOwner(owner.address);
+        });
+
+        it("should not allow to upgrade from non-owner", async () => {
+            const smartLoansFactoryV2 = await (new MockUpgradedSmartLoansFactory__factory(owner).deploy());
+            await expect(proxy.connect(owner).upgradeTo(smartLoansFactoryV2.address))
+                .to.be.revertedWith("Transaction reverted: function selector was not recognized and there's no fallback function");
+        });
+
+
+        it("should upgrade", async () => {
+            const smartLoansFactoryV2 = await (new MockUpgradedSmartLoansFactory__factory(owner).deploy());
+
+            await proxy.connect(admin).upgradeTo(smartLoansFactoryV2.address);
+
+            let smartLoansFactoryUpgraded = (await new ethers.Contract(smartLoansFactory.address, MockSmartLoansFactoryArtifact.abi)) as MockUpgradedSmartLoansFactory;
+
+            //The mock exchange has a hardcoded return value of 1337
+            expect(await smartLoansFactoryUpgraded.connect(owner).newMockedFunction()).to.be.equal(1337);
+            // The contract's borrowers registry should stay unchanged
+            expect(ownerLoanAddress).to.be.equal(await smartLoansFactory.getLoanForOwner(owner.address));
+        });
+    });
+});


### PR DESCRIPTION
* Make Pangolin Exchange upgradeable
* Adjust tests
* Add tests for PE upgradeability behind a proxy
* Annotate functions and methods using redstone-evm-connector
* Init ReentrancyGuard